### PR TITLE
Update datagrip to 2016.3.3

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,6 +1,6 @@
 cask 'datagrip' do
-  version '2016.3.2'
-  sha256 '1ffb0849dfc4eff4158da1cc744f09ebbf12f1087568445a3de4abc518b2733f'
+  version '2016.3.3'
+  sha256 '3d7b52ad66275fd3d61d1338521ac61981d3b01924fd784c71036769192f014b'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version}.dmg"
   name 'DataGrip'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This PR has been semi-auomatically created by the [jetbrains-cask-bot](https://github.com/leipert/jetbrains-cask-bot)